### PR TITLE
fix: Correct arg order

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,28 @@
-export interface withLocalTmpDirOptions {
+export interface WithLocalTmpDirOptions {
+  /**
+   * If false then tmp directory will NOT be deleted if it contains files
+   * */
   unsafeCleanup?: boolean
+  /**
+   * A subfolder to create the tmp directory in
+   * */
   dir?: string
+  /**
+   * A prefix to prepend to the name of the tmp directory
+   * */
   prefix?: string
 }
-declare function withLocalTmpDirFunc(args: withLocalTmpDirOptions | (() => Promise<void>)): Promise<string>
+/**
+ * A callback which runs in the context of a temporary directory. After the callback is completed context is returned to the original directory.
+ * */
+export type TmpDirCallback = () => Promise<void>;
+
+export type WithLocalTmpDirArgs = TmpDirCallback | WithLocalTmpDirOptions;
+
+/**
+ * A promise returned from withLocalTmpDir that, when executed, cleans up the tmp directory. Can be used instead of the callback.
+ * */
+export type ResetFunc = Promise<void>;
+
+declare function withLocalTmpDirFunc(...args: WithLocalTmpDirArgs[]): ResetFunc
 export default withLocalTmpDirFunc


### PR DESCRIPTION
After all that I still missed that the arg order didn't cover all use-cases :sweat_smile: 

It only covered `withLocalTmpDir({}, () => ...);` but not any other order, or no args at all. Oops. 

PR corrects args typing to be optional and order-independent as well as annotations for args and return value.